### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,32 @@ pip install -r requirements.txt
 python app.py
 ```
 
-# Examples
+# API Endpoints
 
-## Top teams (ranking)
+## Teams
+
+### Team Rankings
 ```http
 GET /api/v1/teams/rankings
+GET /api/v1/teams/rankings/<type>
+GET /api/v1/teams/rankings/<type>/<year>/<month>/<day>
 ```
-Returns the HLTV or VALVE team ranking.
+Returns the HLTV or VALVE team ranking. Available types: `hltv` (default), `valve`.
 ![ranking](https://github.com/user-attachments/assets/829c924d-7730-468b-be57-75586fb242b2)
 
-
-## Team Search
+### Team Search
 ```http
 GET /api/v1/teams/search/<name>
 ```
 Searches for a team by name.
 
-## Team Profile
+### Team Profile
 ```http
 GET /api/v1/teams/<id>/<team_name>
 ```
 Returns the team profile.
 
-## Team matches
+### Team Matches
 ```http
 GET /api/v1/teams/<id>/matches
 GET /api/v1/teams/<id>/matches/<offset>
@@ -41,6 +44,8 @@ GET /api/v1/teams/<id>/matches/<offset>
 Returns a list of team matches (optionally with an offset).
 
 ## Results
+
+### Results
 ```http
 GET /api/v1/results/
 GET /api/v1/results/<offset>
@@ -48,35 +53,46 @@ GET /api/v1/results/<offset>
 Returns the results of HLTV matches.
 ![results](https://github.com/user-attachments/assets/020eb6fb-8c11-409d-a2d6-5685d5a44385)
 
-
-## Featured Results
+### Featured Results
 ```http
 GET /api/v1/results/featured
 ```
 Returns featured results.
 ![results_featured](https://github.com/user-attachments/assets/cc3b7740-6045-4401-83c7-515043b2b794)
 
+## Matches
 
-## Upcoming matches
+### Upcoming Matches
 ```http
 GET /api/v1/matches/upcoming
 ```
 Returns upcoming matches.
 
-## Match details
+### Match Details
 ```http
 GET /api/v1/matches/<id>/<match_name>
 ```
 Returns details of the selected match.
 
-## Player Search
+## Players
+
+### Player Search
 ```http
 GET /api/v1/players/search/<name>
 ```
 Searches for a player by name.
 
-## Player Profile
+### Player Profile
 ```http
 GET /api/v1/players/<id>/<player_name>
 ```
 Returns the player profile.
+
+## News
+
+### News
+```http
+GET /api/v1/news
+GET /api/v1/news/<year>/<month>/
+```
+Returns news from HLTV. If no parameters provided, returns current month's news.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cssselect==1.3.0
 defusedxml==0.7.1
 Deprecated==1.2.18
 filelock==3.18.0
-Flask==3.1.0
+flask>=3.1.1
 Flask-Limiter==3.12
 h11==0.14.0
 hyperlink==21.0.0
@@ -40,14 +40,14 @@ Pygments==2.19.1
 pyOpenSSL==25.0.0
 PySocks==1.7.1
 queuelib==1.7.0
-requests==2.32.3
+requests>=2.32.4
 requests-file==2.1.0
 rich==13.9.4
 Scrapy==2.12.0
 scrapy-selenium==0.0.7
 selenium==4.30.0
 service-identity==24.2.0
-setuptools==77.0.3
+setuptools>=78.1.1
 sniffio==1.3.1
 sortedcontainers==2.4.0
 tldextract==5.1.3
@@ -55,7 +55,7 @@ trio==0.29.0
 trio-websocket==0.12.2
 Twisted==24.11.0
 typing_extensions==4.12.2
-urllib3==2.3.0
+urllib3>=2.5.0
 w3lib==2.3.1
 websocket-client==1.8.0
 Werkzeug==3.1.3


### PR DESCRIPTION
This pull request updates the `README.md` to improve and reorganize the API documentation. The changes clarify available endpoints, group them by resource (Teams, Results, Matches, Players, News), and add missing documentation for the News endpoints.

API documentation improvements:

* Reorganized all API endpoints into clear sections by resource (Teams, Results, Matches, Players, News) for easier navigation and understanding.
* Added documentation for the News endpoints (`GET /api/v1/news` and `GET /api/v1/news/<year>/<month>/`), which were previously missing.
* Enhanced endpoint descriptions and grouped related endpoints under subsections (e.g., Team Rankings, Team Search, Team Profile) for consistency and clarity.